### PR TITLE
Avoid shell error if a variable is empty

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -39,7 +39,7 @@ fi
 #     wget "http://php.net/distributions/php-${PHP_VERSION_NUM}.tar.xz"
 # fi
 
-if [ $JAVA = "true" ] ; then
+if [ _$JAVA = "_true" ] ; then
 cat << EOF
 RUN if [ \$(grep 'VERSION_ID="8"' /etc/os-release) ] ; then \\
     echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \\
@@ -66,15 +66,15 @@ RUN if [ \$(grep 'VERSION_ID="8"' /etc/os-release) ] ; then \\
 EOF
 fi
 
-if [ $MYSQL_CLIENT = "true" ] ; then
+if [ _$MYSQL_CLIENT = "_true" ] ; then
     echo "RUN apt-get -y install mysql-client"
 fi
 
-if [ $POSTGRES_CLIENT = "true" ] ; then
+if [ _$POSTGRES_CLIENT = "_true" ] ; then
     echo "RUN apt-get -y install postgresql-client"
 fi
 
-if [ $DOCKERIZE = "true" ] ; then
+if [ _$DOCKERIZE = "_true" ] ; then
 DOCKERIZE_VERSION="v0.6.1"
 
 cat << EOF
@@ -98,7 +98,7 @@ echo "RUN perl -MCPAN -e 'install XML::Generator'"
 # install lsb-release, etc., for testing linux distro
 echo "RUN apt-get update && apt-get -y install lsb-release unzip"
 
-if [ $BROWSERS = "true" ] ; then
+if [ _$BROWSERS = "_true" ] ; then
 cat << EOF
 RUN if [ \$(grep 'VERSION_ID="8"' /etc/os-release) ] ; then \\
     echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \\


### PR DESCRIPTION
If a variable is not set, the `if` conditions are not valid and therefore the generate.sh script display ugly messages about `line 42: [: =: unary operator expected`.